### PR TITLE
Fixed usage instructions to place script in <head>

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,12 +6,12 @@ The modernizr-rails gem will include the [Modernizr.js](https://github.com/Moder
 Add the following to your GemFile:<br> 
 `gem 'modernizr-rails'`<br>
 
-Then add the following to your application.js manifest:<br>
-`//= require modernizr`<br>
+Modernizr should be added to the `<head>` of your HTML so that feature detection happens before anything else.
+You can use the rails helper `=javascript_include_tag 'modernizr'` or `=javascript_include_tag 'modernizr.min'`
+for the minified version.
 
-Or to use the minified version:
-
-`//= require modernizr.min`<br>
+Note: The rails 3+ asset pipeline should minify the javascript in production automatically so it should
+not be completely necessary to use the `modernizr.min` version.
 
 Don't forget to run `bundle update` after upgrading to the latest gem version to ensure it's used by your rails app.
 


### PR DESCRIPTION
Modernizr is meant to be added to the <head> tag and not loaded after
the <body> tag to ensure feature detection is run immediately. Also
added mention of the asset pipeline's ability to automatically minify
your javascript in production.

This addresses issue #4
