### PR TITLE
Add license to gemspec

### DIFF
--- a/modernizr-rails.gemspec
+++ b/modernizr-rails.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.homepage    = "http://rubygems.org/gems/modernizr-rails"
   s.summary     = %q{Gem wrapper to include the Modernizr.js library via the asset pipeline.}
   s.description = %q{This Modernizr.js was built using the at http://www.modernizr.com/download/ with all options enabled.}
+  s.license     = "MIT"
 
   s.rubyforge_project = "modernizr-rails"
   


### PR DESCRIPTION
I was trying to determine the licenses for my dependencies. I found that the RubyGems API will return the license, but only if it is specified in your gemspec file.
